### PR TITLE
[S3] handle "/" in container name

### DIFF
--- a/dev/cosbench-s3/src/com/intel/cosbench/api/S3Stor/S3Storage.java
+++ b/dev/cosbench-s3/src/com/intel/cosbench/api/S3Stor/S3Storage.java
@@ -133,8 +133,8 @@ public class S3Storage extends NoneStorage {
     public void createContainer(String container, Config config) {
         super.createContainer(container, config);
         try {
+            container = container.split("/")[0];
             if(!client.doesBucketExist(container)) {
-                
                 client.createBucket(container);
             }
         } catch(AmazonServiceException ase) {
@@ -173,6 +173,7 @@ public class S3Storage extends NoneStorage {
     public void deleteContainer(String container, Config config) {
         super.deleteContainer(container, config);
         try {
+            container = container.split("/")[0];
             if(client.doesBucketExist(container)) {
                 client.deleteBucket(container);
             }


### PR DESCRIPTION
S3 client crashed without error notification nor exception when a `/` was present in the bucket name during `createBucket` operation.

The solution is to split the container at the '/' and keeping only the first part.