### PR TITLE
Do not crash when encountering empty stack traces

### DIFF
--- a/dev/cosbench-driver/src/com/intel/cosbench/driver/operator/AbstractOperator.java
+++ b/dev/cosbench-driver/src/com/intel/cosbench/driver/operator/AbstractOperator.java
@@ -114,8 +114,15 @@ abstract class AbstractOperator implements Operator {
     protected abstract void operate(int idx, int all, Session session);
 
     public static void errorStatisticsHandle(Exception e, Session session, String target){
-            String trace = e.getStackTrace()[0].toString();
-            trace = e.getCause() == null ? trace : trace + e.getCause().getStackTrace()[0].toString();
+            String trace = null;
+            try {
+                trace = e.getStackTrace()[0].toString();
+                trace = e.getCause() == null ? trace : trace + e.getCause().getStackTrace()[0].toString();
+            } catch (ArrayIndexOutOfBoundsException ignored) {
+                LOGGER.debug("Got an error with an empty stack trace. " +
+                        "Run the driver with -XX:-OmitStackTraceInFastThrow to prevent this.", e);
+                trace = "<undefined>";
+            }
             ErrorStatistics errorStatistics = session.getErrorStatistics();
             HashMap<String, String> stackTraceAndTargets = errorStatistics.getStackTraceAndTargets();
             synchronized (stackTraceAndTargets) {

--- a/release/cosbench-start.sh
+++ b/release/cosbench-start.sh
@@ -43,7 +43,7 @@ mkdir -p log
 
 echo "Launching osgi framwork ... "
 
-/usr/bin/nohup java -Dcosbench.tomcat.config=$TOMCAT_CONFIG -server -cp main/* org.eclipse.equinox.launcher.Main -configuration $OSGI_CONFIG -console $OSGI_CONSOLE_PORT 1> $BOOT_LOG 2>&1 &
+/usr/bin/nohup java -XX:-OmitStackTraceInFastThrow -Dcosbench.tomcat.config=$TOMCAT_CONFIG -server -cp main/* org.eclipse.equinox.launcher.Main -configuration $OSGI_CONFIG -console $OSGI_CONSOLE_PORT 1> $BOOT_LOG 2>&1 &
 
 if [ $? -ne 0 ];
 then


### PR DESCRIPTION
Recent JVMs run with OmitStackTraceInFastThrow enabled by default. When an exception occurs several times, the stack trace is no more generated, but COSBench still tries to parse it and fails miserably. One solution is to run COSBench with `-XX:-OmitStackTraceInFastThrow`. For extra security, we will also ignore such empty stack traces.

Fixes: intel-cloud/cosbench#323
Fixes: intel-cloud/cosbench#331